### PR TITLE
*: TiDB multi-tenant support - part 1

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -311,7 +312,12 @@ func newDDL(ctx context.Context, options ...Option) *ddl {
 		manager = owner.NewMockManager(ctx, id)
 		syncer = NewMockSchemaSyncer()
 	} else {
-		manager = owner.NewOwnerManager(ctx, etcdCli, ddlPrompt, id, DDLOwnerKey)
+		if config.GetGlobalConfig().Tenant.IsTenant {
+			manager = owner.NewOwnerManager(ctx, etcdCli, ddlPrompt, id, DDLOwnerKey+strconv.FormatInt(int64(config.GetGlobalConfig().Tenant.TenantId), 10))
+		} else {
+			manager = owner.NewOwnerManager(ctx, etcdCli, ddlPrompt, id, DDLOwnerKey)
+		}
+
 		syncer = util.NewSchemaSyncer(ctx, etcdCli, id, manager)
 		deadLockCkr = util.NewDeadTableLockChecker(etcdCli)
 	}
@@ -500,6 +506,24 @@ func (d *ddl) genPlacementPolicyID() (int64, error) {
 		m := meta.NewMeta(txn)
 		var err error
 		ret, err = m.GenPlacementPolicyID()
+		return err
+	})
+
+	return ret, err
+}
+
+func (d *ddl) genTableIDs(count int) ([]int64, error) {
+	var ret []int64
+	err := kv.RunInNewTxn(context.Background(), d.store, true, func(ctx context.Context, txn kv.Transaction) error {
+		failpoint.Inject("mockGenTableIDFail", func(val failpoint.Value) {
+			if val.(bool) {
+				failpoint.Return(errors.New("gofail genTableIDs error"))
+			}
+		})
+
+		m := meta.NewMeta(txn)
+		var err error
+		ret, err = m.GenTableIDs(count)
 		return err
 	})
 

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -135,6 +135,7 @@ func (d *ddl) CreateSchemaWithInfo(
 	if err != nil {
 		return errors.Trace(err)
 	}
+
 	dbInfo.ID = genIDs[0]
 
 	job := &model.Job{
@@ -2125,11 +2126,28 @@ func buildTableInfoWithStmt(ctx sessionctx.Context, s *ast.CreateTableStmt, dbCh
 }
 
 func (d *ddl) assignTableID(tbInfo *model.TableInfo) error {
-	genIDs, err := d.genGlobalIDs(1)
+	var genIDs []int64
+	var err error
+
+	if config.GetGlobalConfig().Tenant.IsTenant {
+		genIDs, err = d.genTableIDs(1)
+	} else {
+		genIDs, err = d.genGlobalIDs(1)
+	}
+
 	if err != nil {
 		return errors.Trace(err)
 	}
-	tbInfo.ID = genIDs[0]
+
+	if config.GetGlobalConfig().Tenant.IsTenant && genIDs[0] >= 1<<config.BitsReserved4TenantTableId {
+		return errors.Trace(errors.New("table id for current tenant overflows"))
+	}
+
+	if config.GetGlobalConfig().Tenant.IsTenant {
+		tbInfo.ID = genIDs[0] + int64(config.GetGlobalConfig().Tenant.TenantId)<<config.BitsReserved4TenantTableId
+	} else {
+		tbInfo.ID = genIDs[0]
+	}
 	return nil
 }
 

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/ddl/placement"
 	"github.com/pingcap/tidb/meta/autoid"
 	"github.com/pingcap/tidb/parser/model"
@@ -330,17 +331,23 @@ func GetSequenceByName(is InfoSchema, schema, sequence model.CIStr) (util.Sequen
 }
 
 func init() {
-	// Initialize the information shema database and register the driver to `drivers`
+	// Initialize the information schema database and register the driver to `drivers`
 	dbID := autoid.InformationSchemaDBID
 	infoSchemaTables := make([]*model.TableInfo, 0, len(tableNameToColumns))
 	for name, cols := range tableNameToColumns {
 		tableInfo := buildTableMeta(name, cols)
 		infoSchemaTables = append(infoSchemaTables, tableInfo)
 		var ok bool
-		tableInfo.ID, ok = tableIDMap[tableInfo.Name.O]
+		_, ok = tableIDMap[tableInfo.Name.O]
 		if !ok {
 			panic(fmt.Sprintf("get information_schema table id failed, unknown system table `%v`", tableInfo.Name.O))
 		}
+
+		if config.GetGlobalConfig().Tenant.IsTenant {
+			tableIDMap[tableInfo.Name.O] += int64(config.GetGlobalConfig().Tenant.TenantId) << config.BitsReserved4TenantTableId
+		}
+
+		tableInfo.ID = tableIDMap[tableInfo.Name.O]
 		for i, c := range tableInfo.Columns {
 			c.ID = int64(i) + 1
 		}

--- a/infoschema/metrics_schema.go
+++ b/infoschema/metrics_schema.go
@@ -17,6 +17,7 @@ package infoschema
 import (
 	"bytes"
 	"fmt"
+	"github.com/pingcap/tidb/config"
 	"sort"
 	"strconv"
 	"strings"
@@ -38,9 +39,14 @@ const (
 )
 
 func init() {
+	var tableID int64
 	// Initialize the metric schema database and register the driver to `drivers`.
 	dbID := autoid.MetricSchemaDBID
-	tableID := dbID + 1
+	if config.GetGlobalConfig().Tenant.IsTenant {
+		tableID = dbID + 1 + int64(config.GetGlobalConfig().Tenant.TenantId)<<config.BitsReserved4TenantTableId
+	} else {
+		tableID = dbID + 1
+	}
 	metricTables := make([]*model.TableInfo, 0, len(MetricTableMap))
 	for name, def := range MetricTableMap {
 		cols := def.genColumnInfos()

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/pingcap/tidb/meta"
 	"io/fs"
 	"os"
 	"runtime"
@@ -200,6 +201,11 @@ func main() {
 	printInfo()
 	setupBinlogClient()
 	setupMetrics()
+
+	// Config meta information for tenant
+	if config.GetGlobalConfig().Tenant.IsTenant {
+		meta.SetTenant(config.GetGlobalConfig().Tenant.TenantId)
+	}
 
 	storage, dom := createStoreAndDomain()
 	svr := createServer(storage, dom)
@@ -620,7 +626,6 @@ func setGlobalVars() {
 		variable.SetSysVar(variable.Hostname, hostname)
 	}
 	variable.GlobalLogMaxDays.Store(int32(config.GetGlobalConfig().Log.File.MaxDays))
-
 	if cfg.Security.EnableSEM {
 		sem.Enable()
 	}


### PR DESCRIPTION
In this patch, TiDB provides the initial support of multi-tenant. Multiple TiDB tenants share PD and Tikv
in the cluster. But each tenant has seperated meta data and user data.

1. two new configuration variable are introduced
    [tenant] is-tenant, tenant mode is turned on or not
    [tenant] tenant-id, whose default value is 0. Valid range is [0, uint16 max)

2. a new key "Tables" is used for table id generation under tenant mode.

Signed-off-by: BornChanger <dawn_catcher@126.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #4 

Problem Summary:

This patch separates meta data and user data of TiDB tenants.  64 bit type of table ids (including schema tables) has 2 parts now. Higher order 2 bytes are used for tenant id, and lower order 4 bytes for the real table ids. So, under multiple tenancy mode, each tenancy can have no more than 1^48 tables.  The limit is fairly enough though.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
