### PR TITLE
*: add support to create/alter user with resource group option

### DIFF
--- a/executor/simple.go
+++ b/executor/simple.go
@@ -827,13 +827,21 @@ func (e *SimpleExec) executeCreateUser(ctx context.Context, s *ast.CreateUserStm
 		lockAccount = "Y"
 	}
 
-	var userAttributes any = nil
+	var userAttributes = ""
 	if s.CommentOrAttributeOption != nil {
-		if s.CommentOrAttributeOption.Type == ast.UserCommentType {
-			userAttributes = fmt.Sprintf("{\"metadata\": {\"comment\": \"%s\"}}", s.CommentOrAttributeOption.Value)
-		} else if s.CommentOrAttributeOption.Type == ast.UserAttributeType {
-			userAttributes = fmt.Sprintf("{\"metadata\": %s}", s.CommentOrAttributeOption.Value)
+		if s.CommentOrAttributeOption.Type != ast.UserResourceGroupName {
+			userAttributes = `{"metadata": {"resource group": "default"`
+			if s.CommentOrAttributeOption.Type == ast.UserCommentType {
+				userAttributes += fmt.Sprintf(`, "comment": "%s"`, s.CommentOrAttributeOption.Value)
+			} else if s.CommentOrAttributeOption.Type == ast.UserAttributeType {
+				userAttributes = fmt.Sprintf(`,  %s`, s.CommentOrAttributeOption.Value)
+			}
+			userAttributes += `}}`
+		} else {
+			userAttributes = fmt.Sprintf(`{"metadata": {"resource group": "%s"}}`, s.CommentOrAttributeOption.Value)
 		}
+	} else {
+		userAttributes = `{"metadata": {"resource group": "default"}}`
 	}
 
 	tokenIssuer := ""
@@ -1105,8 +1113,10 @@ func (e *SimpleExec) executeAlterUser(ctx context.Context, s *ast.AlterUserStmt)
 			newAttributesStr := ""
 			if s.CommentOrAttributeOption.Type == ast.UserCommentType {
 				newAttributesStr = fmt.Sprintf(`{"metadata": {"comment": "%s"}}`, s.CommentOrAttributeOption.Value)
-			} else {
+			} else if s.CommentOrAttributeOption.Type == ast.UserAttributeType {
 				newAttributesStr = fmt.Sprintf(`{"metadata": %s}`, s.CommentOrAttributeOption.Value)
+			} else {
+				newAttributesStr = fmt.Sprintf(`{"metadata": {"resource group": "%s"}}`, s.CommentOrAttributeOption.Value)
 			}
 			fields = append(fields, alterField{"user_attributes=json_merge_patch(user_attributes, %?)", newAttributesStr})
 		}

--- a/parser/ast/misc.go
+++ b/parser/ast/misc.go
@@ -1498,6 +1498,7 @@ const (
 
 	UserCommentType
 	UserAttributeType
+	UserResourceGroupName
 )
 
 type PasswordOrLockOption struct {
@@ -1538,6 +1539,9 @@ func (c *CommentOrAttributeOption) Restore(ctx *format.RestoreCtx) error {
 		ctx.WriteString(c.Value)
 	} else if c.Type == UserAttributeType {
 		ctx.WriteKeyWord(" ATTRIBUTE ")
+		ctx.WriteString(c.Value)
+	} else if c.Type == UserResourceGroupName {
+		ctx.WriteKeyWord(" RESOURCE GROUP ")
 		ctx.WriteString(c.Value)
 	}
 	return nil

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -12925,6 +12925,11 @@ CommentOrAttributeOption:
 		$$ = &ast.CommentOrAttributeOption{Type: ast.UserAttributeType, Value: $2}
 	}
 
+|  "RESOURCE" "GROUP" stringLit
+{
+	$$ = &ast.CommentOrAttributeOption{Type: ast.UserResourceGroupName, Value: $3}
+}
+
 PasswordOrLockOptions:
 	{
 		$$ = []*ast.PasswordOrLockOption{}


### PR DESCRIPTION
Signed-off-by: BornChanger <dawn_catcher@126.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #20 

Problem Summary:

New syntax support resource group specification at create/alter user time.

e.g. 
create user usr1@'%' identified by 'password1' resource group 'rg1';  // resource group rg1 is bound to usr1
create user usr2@'%' identified by 'password2'; // resource group 'default' is bound to usr2
alter user usr2 resource group 'rg2'; // usr2 is bound to resource group rg2 now


### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
