### PR TITLE
*: pass user's resource group name to sessionVars.ResourceGroupName

### DIFF
--- a/executor/simple.go
+++ b/executor/simple.go
@@ -830,7 +830,7 @@ func (e *SimpleExec) executeCreateUser(ctx context.Context, s *ast.CreateUserStm
 	var userAttributes = ""
 	if s.CommentOrAttributeOption != nil {
 		if s.CommentOrAttributeOption.Type != ast.UserResourceGroupName {
-			userAttributes = `{"metadata": {"resource group": "default"`
+			userAttributes = `{"metadata": {"resource_group": "default"`
 			if s.CommentOrAttributeOption.Type == ast.UserCommentType {
 				userAttributes += fmt.Sprintf(`, "comment": "%s"`, s.CommentOrAttributeOption.Value)
 			} else if s.CommentOrAttributeOption.Type == ast.UserAttributeType {
@@ -838,10 +838,10 @@ func (e *SimpleExec) executeCreateUser(ctx context.Context, s *ast.CreateUserStm
 			}
 			userAttributes += `}}`
 		} else {
-			userAttributes = fmt.Sprintf(`{"metadata": {"resource group": "%s"}}`, s.CommentOrAttributeOption.Value)
+			userAttributes = fmt.Sprintf(`{"metadata": {"resource_group": "%s"}}`, s.CommentOrAttributeOption.Value)
 		}
 	} else {
-		userAttributes = `{"metadata": {"resource group": "default"}}`
+		userAttributes = `{"metadata": {"resource_group": "default"}}`
 	}
 
 	tokenIssuer := ""
@@ -1116,7 +1116,7 @@ func (e *SimpleExec) executeAlterUser(ctx context.Context, s *ast.AlterUserStmt)
 			} else if s.CommentOrAttributeOption.Type == ast.UserAttributeType {
 				newAttributesStr = fmt.Sprintf(`{"metadata": %s}`, s.CommentOrAttributeOption.Value)
 			} else {
-				newAttributesStr = fmt.Sprintf(`{"metadata": {"resource group": "%s"}}`, s.CommentOrAttributeOption.Value)
+				newAttributesStr = fmt.Sprintf(`{"metadata": {"resource_group": "%s"}}`, s.CommentOrAttributeOption.Value)
 			}
 			fields = append(fields, alterField{"user_attributes=json_merge_patch(user_attributes, %?)", newAttributesStr})
 		}

--- a/privilege/privilege.go
+++ b/privilege/privilege.go
@@ -16,7 +16,6 @@ package privilege
 
 import (
 	"crypto/tls"
-
 	"github.com/pingcap/tidb/parser/auth"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/sessionctx"
@@ -60,7 +59,7 @@ type Manager interface {
 
 	// ConnectionVerification verifies user privilege for connection.
 	// Requires exact match on user name and host name.
-	ConnectionVerification(user *auth.UserIdentity, authUser, authHost string, auth, salt []byte, tlsState *tls.ConnectionState) error
+	ConnectionVerification(user *auth.UserIdentity, authUser, authHost string, auth, salt []byte, tlsState *tls.ConnectionState) (string, error)
 
 	// GetAuthWithoutVerification uses to get auth name without verification.
 	// Requires exact match on user name and host name.

--- a/privilege/privileges/cache.go
+++ b/privilege/privileges/cache.go
@@ -102,6 +102,7 @@ type UserRecord struct {
 	AuthPlugin           string
 	AuthTokenIssuer      string
 	Email                string
+	ResourceGroup        string
 }
 
 // NewUserRecord return a UserRecord, only use for unit test.
@@ -682,6 +683,18 @@ func (p *MySQLPrivilege) decodeUserTableRow(row chunk.Row, fs []*ast.ResultField
 					return err
 				}
 				value.Email = email
+			}
+
+			pathExpr, err = types.ParseJSONPathExpr("$.metadata.resource_group")
+			if err != nil {
+				return err
+			}
+			if resourceGroup, found := bj.Extract([]types.JSONPathExpression{pathExpr}); found {
+				resourceGroup, err := resourceGroup.Unquote()
+				if err != nil {
+					return err
+				}
+				value.ResourceGroup = resourceGroup
 			}
 		default:
 			value.assignUserOrHost(row, i, f)

--- a/privilege/privileges/privileges.go
+++ b/privilege/privileges/privileges.go
@@ -437,6 +437,11 @@ func (p *UserPrivileges) ConnectionVerification(user *auth.UserIdentity, authUse
 
 	p.user = authUser
 	p.host = record.Host
+
+	// special handling to existing users or root user initialized with insecure
+	if record.ResourceGroup == "" {
+		record.ResourceGroup = "default"
+	}
 	return record.ResourceGroup, nil
 }
 

--- a/privilege/privileges/privileges.go
+++ b/privilege/privileges/privileges.go
@@ -338,15 +338,17 @@ func checkAuthTokenClaims(claims map[string]interface{}, record *UserRecord, tok
 }
 
 // ConnectionVerification implements the Manager interface.
-func (p *UserPrivileges) ConnectionVerification(user *auth.UserIdentity, authUser, authHost string, authentication, salt []byte, tlsState *tls.ConnectionState) error {
+func (p *UserPrivileges) ConnectionVerification(user *auth.UserIdentity, authUser, authHost string, authentication, salt []byte, tlsState *tls.ConnectionState) (string, error) {
 	hasPassword := "YES"
 	if len(authentication) == 0 {
 		hasPassword = "NO"
 	}
+
+	// FIXME
 	if SkipWithGrant {
 		p.user = authUser
 		p.host = authHost
-		return nil
+		return "default", nil
 	}
 
 	mysqlPriv := p.Handle.Get()
@@ -354,27 +356,26 @@ func (p *UserPrivileges) ConnectionVerification(user *auth.UserIdentity, authUse
 	if record == nil {
 		logutil.BgLogger().Error("get authUser privilege record fail",
 			zap.String("authUser", authUser), zap.String("authHost", authHost))
-		return ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
+		return "", ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
 	}
-
 	globalPriv := mysqlPriv.matchGlobalPriv(authUser, authHost)
 	if globalPriv != nil {
 		if !p.checkSSL(globalPriv, tlsState) {
 			logutil.BgLogger().Error("global priv check ssl fail",
 				zap.String("authUser", authUser), zap.String("authHost", authHost))
-			return ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
+			return "", ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
 		}
 	}
 
 	pwd := record.AuthenticationString
 	if !p.isValidHash(record) {
-		return ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
+		return "", ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
 	}
 
 	if record.AuthPlugin == mysql.AuthTiDBAuthToken {
 		if len(authentication) == 0 {
 			logutil.BgLogger().Error("empty authentication")
-			return ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
+			return "", ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
 		}
 		tokenString := string(hack.String(authentication[:len(authentication)-1]))
 		var (
@@ -383,11 +384,11 @@ func (p *UserPrivileges) ConnectionVerification(user *auth.UserIdentity, authUse
 		)
 		if claims, err = GlobalJWKS.checkSigWithRetry(tokenString, 1); err != nil {
 			logutil.BgLogger().Error("verify JWT failed", zap.Error(err))
-			return ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
+			return "", ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
 		}
 		if err = checkAuthTokenClaims(claims, record, defaultTokenLife); err != nil {
 			logutil.BgLogger().Error("check claims failed", zap.Error(err))
-			return ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
+			return "", ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
 		}
 	} else if len(pwd) > 0 && len(authentication) > 0 {
 		switch record.AuthPlugin {
@@ -395,11 +396,11 @@ func (p *UserPrivileges) ConnectionVerification(user *auth.UserIdentity, authUse
 			hpwd, err := auth.DecodePassword(pwd)
 			if err != nil {
 				logutil.BgLogger().Error("decode password string failed", zap.Error(err))
-				return ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
+				return "", ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
 			}
 
 			if !auth.CheckScrambledPassword(salt, hpwd, authentication) {
-				return ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
+				return "", ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
 			}
 		case mysql.AuthCachingSha2Password, mysql.AuthTiDBSM3Password:
 			authok, err := auth.CheckHashingPassword([]byte(pwd), string(authentication), record.AuthPlugin)
@@ -408,22 +409,22 @@ func (p *UserPrivileges) ConnectionVerification(user *auth.UserIdentity, authUse
 			}
 
 			if !authok {
-				return ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
+				return "", ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
 			}
 		case mysql.AuthSocket:
 			if string(authentication) != authUser && string(authentication) != pwd {
 				logutil.BgLogger().Error("Failed socket auth", zap.String("authUser", authUser),
 					zap.String("socket_user", string(authentication)),
 					zap.String("authentication_string", pwd))
-				return ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
+				return "", ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
 			}
 		default:
 			logutil.BgLogger().Error("unknown authentication plugin", zap.String("authUser", authUser), zap.String("plugin", record.AuthPlugin))
-			return ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
+			return "", ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
 		}
 	} else if len(pwd) > 0 || len(authentication) > 0 {
 		if record.AuthPlugin != mysql.AuthSocket {
-			return ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
+			return "", ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
 		}
 	}
 
@@ -431,12 +432,12 @@ func (p *UserPrivileges) ConnectionVerification(user *auth.UserIdentity, authUse
 	locked := record.AccountLocked
 	if locked {
 		logutil.BgLogger().Error(fmt.Sprintf("Access denied for authUser '%s'@'%s'. Account is locked.", authUser, authHost))
-		return errAccountHasBeenLocked.FastGenByArgs(user.Username, user.Hostname)
+		return "", errAccountHasBeenLocked.FastGenByArgs(user.Username, user.Hostname)
 	}
 
 	p.user = authUser
 	p.host = record.Host
-	return nil
+	return record.ResourceGroup, nil
 }
 
 type checkResult int

--- a/server/conn.go
+++ b/server/conn.go
@@ -845,6 +845,7 @@ func (cc *clientConn) openSessionAndDoAuth(authData []byte, authPlugin string) e
 	} else if err = cc.ctx.Auth(userIdentity, authData, cc.salt); err != nil {
 		return err
 	}
+
 	cc.ctx.SetPort(port)
 	if cc.dbname != "" {
 		err = cc.useDB(context.Background(), cc.dbname)

--- a/session/session.go
+++ b/session/session.go
@@ -2601,7 +2601,7 @@ func (s *session) Auth(user *auth.UserIdentity, authentication, salt []byte) err
 	if err != nil {
 		return privileges.ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
 	}
-	if err = pm.ConnectionVerification(user, authUser.Username, authUser.Hostname, authentication, salt, s.sessionVars.TLSConnectionState); err != nil {
+	if s.sessionVars.ResourceGroupName, err = pm.ConnectionVerification(user, authUser.Username, authUser.Hostname, authentication, salt, s.sessionVars.TLSConnectionState); err != nil {
 		return err
 	}
 	user.AuthUsername = authUser.Username

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1305,6 +1305,9 @@ type SessionVars struct {
 	// preuseChunkAlloc indicates whether pre statement use chunk alloc
 	// like select @@last_sql_use_alloc
 	preUseChunkAlloc bool
+
+	// Resource group name
+	ResourceGroupName string
 }
 
 // GetNewChunk Attempt to request memory from the chunk pool


### PR DESCRIPTION
Signed-off-by: BornChanger <dawn_catcher@126.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
