### PR TITLE
cancel ddl job once create resource group api return error

### DIFF
--- a/ddl/resource_group.go
+++ b/ddl/resource_group.go
@@ -54,7 +54,8 @@ func onCreateOrAlterResourceGroup(d *ddlCtx, t *meta.Meta, job *model.Job) (ver 
 		job.SchemaID = groupInfo.ID
 		err = infosync.PutResourceGroup(context.TODO(), infosync.ConvertAPIResourceGroup(groupInfo))
 		if err != nil {
-			logutil.BgLogger().Warn("put resource group to etcd failed", zap.Error(err))
+			logutil.BgLogger().Error("put resource group to etcd failed", zap.Error(err))
+			job.State = model.JobStateCancelled
 			return ver, errors.Trace(err)
 		}
 		ver, err = updateSchemaVersion(d, t, job)

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -431,6 +431,7 @@ func doRequest(ctx context.Context, apiName string, addrs []string, route, metho
 					zap.String("url", url),
 					zap.Int("http status", res.StatusCode),
 					zap.Int("address order", idx),
+					zap.ByteString("response body", bodyBytes),
 				)
 				err = ErrHTTPServiceError.FastGen("%s", bodyBytes)
 				if res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusPreconditionFailed {

--- a/domain/infosync/resource_group_manager.go
+++ b/domain/infosync/resource_group_manager.go
@@ -28,15 +28,17 @@ import (
 
 // ResourceGroup is used to conmunicate with ResourGroup Manager.
 type ResourceGroup struct {
+	ID               int64  `json:"id"`
 	Name             string `json:"name"`
 	CPU              string `json:"cpu"`
-	IOBandwidth      string `json:"io_bandwidth"`
-	IOReadBandwidth  string `json:"io_read_bandwidth"`
-	IOWriteBandwidth string `json:"io_write_bandwidth"`
+	IOBandwidth      string `json:"io_bandwidth,omitempty"`
+	IOReadBandwidth  string `json:"io_read_bandwidth,omitempty"`
+	IOWriteBandwidth string `json:"io_write_bandwidth,omitempty"`
 }
 
 func ConvertAPIResourceGroup(modelGroup *model.ResourceGroupInfo) *ResourceGroup {
 	return &ResourceGroup{
+		ID:               modelGroup.ID,
 		Name:             modelGroup.Name.L,
 		CPU:              modelGroup.CPULimiter,
 		IOBandwidth:      modelGroup.IOBandwidth,


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>



### What problem does this PR solve?
```
cancel ddl job once create resource grou api return error
```


- [x] Manual test (add detailed scripts or steps below)
```
MySQL [(none)]> create resource group mytest1 cpu="8000m" io_bandwidth="1000MB/s";
ERROR 8243 (HY000): "quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'"
```
should be

```
MySQL [(none)]> create resource group mytest1 cpu="8000m" io_bandwidth="1000Mi";
```